### PR TITLE
Add files via upload

### DIFF
--- a/functions/f_algal_dynamics.m
+++ b/functions/f_algal_dynamics.m
@@ -20,13 +20,13 @@ substrate_env_cm2= substrate_SA_cm2(environ(:,2)) + substrate_SA_cm2(environ(:,3
 % Simulate algal dynamics
 for t=1:ALGAL.nb_step_algal_dynamics
     
-    actual_algal_consumpt_pct = f_algal_removal(algal_cm2, algal_removal, ALGAL.feeding_prefs, sum(cell_area_cm2)) ;
-    % actual_algal_consumpt_pct gives the total amount (in %) of each alga to be removed based on their availability
+    actual_algal_consump = f_algal_removal(algal_cm2, algal_removal, ALGAL.feeding_prefs, sum(cell_area_cm2)) ;
+    % actual_algal_consumption gives the total amount of each alga (as proportional area) to be removed based on their availability
     % Note that REEF.substrate_SA_cm2 is the surface area of the substrate underneath live corals
     % -> we use now the actual surface area of the reef instead of the planar area (META.total_area_cm2)
 
     % Converts in total amount of cm2 algae that can be consumed
-    max_fish_consump = actual_algal_consumpt_pct*sum(cell_area_cm2);
+    max_fish_consump = actual_algal_consump*sum(cell_area_cm2);
     
     %%%%%%%%%%%%%%%%%% Set up grazing for every cell %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     r = uint16(randperm(length(list_cell)));  % randomize the order of cell to visit

--- a/functions/f_algal_removal.m
+++ b/functions/f_algal_removal.m
@@ -8,6 +8,8 @@
 
 function ALGALREMOVAL2 = f_algal_removal(algal_cm2, ALGALREMOVAL, algal_prefs, total_area_cm2)
 
+% ALGALREMOVAL is now estimated in f_runmodel
+% This is a vector of proportional areas of algae removed due to grazing
 
 total_algal_cm2 = sum(algal_cm2,1) ; % total cover of each algae over the whole grid
 

--- a/functions/f_process_population.m
+++ b/functions/f_process_population.m
@@ -165,8 +165,6 @@ algal_cm2(overshoot<0,1) = algal_cm2(overshoot<0,1) - overshoot(overshoot<0) ;
 % Reduce EAM first (if available)
 algal_cm2(overshoot>0 & algal_cm2(:,1)>0,1) = algal_cm2(overshoot>0 & algal_cm2(:,1)>0,1)...
     - overshoot(overshoot>0 & algal_cm2(:,1)>0) ;
-algal_cm2(overshoot>0 & algal_cm2(:,1)>0,1) = algal_cm2(overshoot>0 & algal_cm2(:,1)>0,1)...
-    - overshoot(overshoot>0 & algal_cm2(:,1)>0) ;
 algal_cm2(algal_cm2(:,1)<0,1)=0; % turn negatives into 0!
 % Update overshoot
 overshoot = sum(algal_cm2,2) + sum(coral_cm2.*id1,2) - new_colocation_cm2 - cell_area_cm2 ;
@@ -175,7 +173,7 @@ algal_cm2(overshoot>0 & algal_cm2(:,4)>0,4) = algal_cm2(overshoot>0 & algal_cm2(
     - overshoot(overshoot>0 & algal_cm2(:,4)>0) ;
 algal_cm2(algal_cm2(:,4)<0,4)=0; % turn negatives into 0!
 % Update overshoot
-overshoot = sum(algal_cm2,2) + sum(coral_cm2.*id1,2) - new_colocation_cm2 - cell_area_cm2 ;
+% overshoot = sum(algal_cm2,2) + sum(coral_cm2.*id1,2) - new_colocation_cm2 - cell_area_cm2 ;
 
  
 % % IF OVERSHOOT IS NEGATIVE -> fill the empty space with EAM


### PR DESCRIPTION
**1. f_algal_removal.m**
- Ddded a comment to clarify that `ALGALREMOVAL` is a vector of proportional areas of algae.

**2. f_algal_dynamics.m**
- Renamed `actual_algal_consumpt_pct` as `actual_algal_consump` (**proportions**, not percentages) + clarification in comments.

**3. f_process_population.m** 
- Deleted the duplicated code line 168:
`algal_cm2(overshoot>0 & algal_cm2(:,1)>0,1) = algal_cm2(overshoot>0 & algal_cm2(:,1)>0,1)  - overshoot(overshoot>0 & algal_cm2(:,1)>0) ;`
- Blocked the last update of overshoot (useless)
- Changed `cell_area_cm2` for `all_cell_areas_cm2` to avoid confusion with `META.cell_area_cm2` (area of each grid cell). `cell_area_cm2` = `substrate_SA_cm2` except for nongrazable cells which take 0 (excluded from grazing calculation).
- Resolved duplicate input arguments of `substrate_SA_cm2` in function `f_algal_dynamics` by defining proper vector of all cell areas except for nongrazable cells (= 0).
- Changed the input argument `REEF` for `REEFn` in statement definition to avoid confusion with multi structure array used in the overarching code. Here, `REEFn.x` = `REEF(n).x`.

**4. f_initialise_population.m**
- Changed the input argument `REEF` for `REEFn` in statement definition (see above).

**5. f_derivecoralcover.m**
- Changed the input argument `REEF` for `REEFn` in statement definition (see above).
